### PR TITLE
fix(mumble-server): use a workaround for the erroneous -supw failure

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -93,7 +93,23 @@ if [ ! -f /data/murmur.sqlite ]; then
 
     echo "SUPERUSER_PASSWORD: $SUPERUSER_PASSWORD"
 
-    /opt/murmur/murmur.x86 -ini "${CONFIGFILE}" -supw "$SUPERUSER_PASSWORD"
+    # Using -supw currently throws a fatal error and exits the program. It has
+    # been fixed in the upstream project by commit d8203ba94 [1], but has not
+    # yet been included in a release. To bypass the issue and allow the entrypoint
+    # script to proceed, we are ignoring the erroneous exit code by executing
+    # `true` if the invocation fails.
+    #
+    # IMPORTANT
+    # Before removing this workaround, be sure to check that the upstream
+    # release actually contains the commit:
+    #
+    #     git tag --contains b7a0867ca935e0bda1057f6760df0551ccb33409 <ref>
+    #
+    # This was previously erroneously removed. See [2] for more information.
+    #
+    # [1]: https://github.com/mumble-voip/mumble/commit/d8203ba94d528b092e0ff5a52a51af28f8f592f1
+    # [2]: https://github.com/sudoforge/docker-mumble-server/issues/121
+    /opt/murmur/murmur.x86 -ini "${CONFIGFILE}" -supw $SUPERUSER_PASSWORD || true
 fi
 
 # Run murmur if not in debug mode


### PR DESCRIPTION
Using -supw currently throws a fatal error and exits the program. It has
been fixed in the upstream project by commit d8203ba94 [1], but has not
yet been included in a release. To bypass the issue and allow the entrypoint
script to proceed, we are ignoring the erroneous exit code by executing
`true` if the invocation fails.

This was previously fixed in commit b1229e09825, but was erroneously
removed in commit b7a0867ca93. Care should be taken to ensure the
upstream release _actually_ contains the fix before reverting this
commit.

[1]: https://github.com/mumble-voip/mumble/commit/d8203ba94d528b092e0ff5a52a51af28f8f592f1

closes #121
references #92 mumble-voip/mumble#3911 mumble-voip/mumble#3998 mumble-voip/mumble#4728