### PR TITLE
revert: "fix(mumble-server): use a workaround for the erroneous -supw…

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -93,24 +93,7 @@ if [ ! -f /data/murmur.sqlite ]; then
 
     echo "SUPERUSER_PASSWORD: $SUPERUSER_PASSWORD"
 
-    # Using -supw currently throws a fatal error and exits the program. It has
-    # been fixed in the upstream project by commit d8203ba94 [1], but has not
-    # yet been included in a release. To bypass the issue and allow the entrypoint
-    # script to proceed, we are ignoring the erroneous exit code by executing
-    # `true` if the invocation fails.
-    #
-    # IMPORTANT
-    # Before removing this workaround, be sure to check that the upstream
-    # release actually contains the commit:
-    #
-    #     git clone git@github.com:mumble-voip/mumble.git
-    #     git -C mumble tag --contains d8203ba94d528b092e0ff5a52a51af28f8f592f1 <ref>
-    #
-    # This was previously erroneously removed. See [2] for more information.
-    #
-    # [1]: https://github.com/mumble-voip/mumble/commit/d8203ba94d528b092e0ff5a52a51af28f8f592f1
-    # [2]: https://github.com/sudoforge/docker-mumble-server/issues/121
-    /opt/murmur/murmur.x86 -ini "$CONFIGFILE" -supw "$SUPERUSER_PASSWORD" || true
+    /opt/murmur/murmur.x86 -ini "$CONFIGFILE" -supw "$SUPERUSER_PASSWORD"
 fi
 
 # Run murmur if not in debug mode


### PR DESCRIPTION
… failure"

This reverts commit 2053b04d71b44032bd1d7a4f49bc2a3e46e3577e.

```
➜ git log --grep "$(git log -1 --format='%s' d8203ba94d528b092e0ff5a52a51af28f8f592f1)" refs/tags/1.3.4
commit 9fc1c188cf23612e0a2083af20735c1ee1571a07
Author: Robert Adam <dev@robert-adam.de>
Date:   Wed Mar 18 12:52:20 2020 +0100

    src/murmur/main.cpp: Use qInfo instead of qFatal for normal logging.

    For some reason qFatal has been used to log information such as the
    version requested by the --version argument.
    abdb5004bb92b28271673e33df9cc3e314f5711a made qFatal exit with an
    exit status of one leading to successful operations that happened
    to contain some print-out to leave an exit status of 1 (#3911).
```

This was further verified by inspecting commit 9fc1c188cf23612e0a2083af20735c1ee1571a07 manually to ensure it contained the appropriate delta.

refs #121 mumble-voip/mumble#3911 mumble-voip/mumble#3998 mumble-voip/mumble#4728